### PR TITLE
Deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ![](https://travis-ci.org/jlenv/julia-build.svg?branch=master)
 
-# julia-build
+# Deprecation Warning:  Likely to be superceeded - use at own risk.
+
+This build script is almost certain to be deprecated in favor of julia-install(forthcoming).
+
+## julia-build
 
 This project was forked from [ruby-build](https://github.com/rbenv/ruby-build), and modified for [julia](https://github.com/JuliaLang/julia).
 


### PR DESCRIPTION
`julia-install` will not require that you `git pull` to be able to build the latest version of Julia.